### PR TITLE
Add AI-generated interview questions via OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-key-here
+OPENAI_MODEL=gpt-5-nano

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -43,3 +43,8 @@ jobs:
             -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+            -Dsonar.sources=src/main/java,src/main/resources
+            -Dsonar.tests=src/test/java
+            -Dsonar.java.binaries=target/classes
+            -Dsonar.java.test.binaries=target/test-classes
+            -Dsonar.coverage.exclusions=src/main/java/com/aicodinginterviewprep/App.java

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,6 +30,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2-
 
+      - name: Build with Maven wrapper
+        run: ./mvnw -q -B verify
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5
         env:
@@ -39,6 +42,4 @@ jobs:
             -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
             -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
             -Dsonar.host.url=https://sonarcloud.io
-
-      - name: Build with Maven wrapper
-        run: ./mvnw -q -B verify
+            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 .DS_Store
 .settings/
 .vscode/
+.env
+SE310_Assignment1_2026.pdf

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
             <version>22.0.2</version>
         </dependency>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.jupiter.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,6 +65,25 @@
                 <configuration>
                     <useModulePath>false</useModulePath>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.openjfx</groupId>

--- a/src/main/java/com/aicodinginterviewprep/App.java
+++ b/src/main/java/com/aicodinginterviewprep/App.java
@@ -1,8 +1,11 @@
 package com.aicodinginterviewprep;
 
+import com.aicodinginterviewprep.service.OpenAiQuestionService;
 import javafx.application.Application;
+import javafx.concurrent.Task;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -15,6 +18,12 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
 public class App extends Application {
+    private final OpenAiQuestionService questionService = new OpenAiQuestionService();
+
+    private TextArea questionOutput;
+    private ComboBox<QuestionType> questionTypeCombo;
+    private Button generateButton;
+
     @Override
     public void start(Stage stage) {
         // Basic JavaFX scaffold for the project setup
@@ -56,12 +65,17 @@ public class App extends Application {
         BorderPane pane = new BorderPane();
         pane.setStyle("-fx-padding: 16;");
 
+        questionOutput = new TextArea("Question will appear here.");
+        questionOutput.setPrefRowCount(8);
+        questionOutput.setWrapText(true);
+        questionOutput.setEditable(false);
+
         VBox left = new VBox(10);
         left.setStyle("-fx-padding: 8; -fx-border-width: 0 1 0 0; -fx-border-color: #ddd;");
         left.prefWidthProperty().bind(pane.widthProperty().multiply(0.40));
         left.getChildren().addAll(
             new Label("Question Output"),
-            new TextArea("Question will appear here.") {{ setPrefRowCount(8); setWrapText(true); setEditable(false); }}
+            questionOutput
         );
 
         VBox center = new VBox(10);
@@ -81,9 +95,17 @@ public class App extends Application {
             new Button("Submit Answer")
         );
 
+        questionTypeCombo = new ComboBox<>();
+        questionTypeCombo.getItems().addAll(QuestionType.values());
+        questionTypeCombo.setValue(QuestionType.BEHAVIOURAL);
+
+        generateButton = new Button("Generate New Question");
+        generateButton.setOnAction(event -> generateQuestion());
+
         HBox bottom = new HBox(12);
         bottom.getChildren().addAll(
-            new Button("Generate New Question"),
+            questionTypeCombo,
+            generateButton,
             new Button("Run AI Evaluation")
         );
 
@@ -128,6 +150,35 @@ public class App extends Application {
 
         tab.setContent(content);
         return tab;
+    }
+
+    private void generateQuestion() {
+        QuestionType type = questionTypeCombo.getValue();
+        generateButton.setDisable(true);
+        questionOutput.setText("Generating question...");
+
+        Task<String> task = new Task<>() {
+            @Override
+            protected String call() throws Exception {
+                return questionService.generateQuestion(type);
+            }
+        };
+
+        task.setOnSucceeded(event -> {
+            questionOutput.setText(task.getValue());
+            generateButton.setDisable(false);
+        });
+
+        task.setOnFailed(event -> {
+            Throwable error = task.getException();
+            String message = error != null ? error.getMessage() : "Unknown error.";
+            questionOutput.setText("Failed to generate question: " + message);
+            generateButton.setDisable(false);
+        });
+
+        Thread worker = new Thread(task, "openai-question-generation");
+        worker.setDaemon(true);
+        worker.start();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/aicodinginterviewprep/QuestionType.java
+++ b/src/main/java/com/aicodinginterviewprep/QuestionType.java
@@ -1,0 +1,17 @@
+package com.aicodinginterviewprep;
+
+public enum QuestionType {
+    BEHAVIOURAL("Behavioural"),
+    THEORY("Theory");
+
+    private final String label;
+
+    QuestionType(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/src/main/java/com/aicodinginterviewprep/config/EnvConfig.java
+++ b/src/main/java/com/aicodinginterviewprep/config/EnvConfig.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public final class EnvConfig {
     private static final Map<String, String> VALUES = load();
@@ -26,28 +27,14 @@ public final class EnvConfig {
     }
 
     private static Map<String, String> load() {
-        Map<String, String> values = new HashMap<>();
         Path envFile = Path.of(".env");
         if (!Files.exists(envFile)) {
-            return values;
+            return new HashMap<>();
         }
-        try {
-            for (String line : Files.readAllLines(envFile)) {
-                String trimmed = line.trim();
-                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                    continue;
-                }
-                int separator = trimmed.indexOf('=');
-                if (separator <= 0) {
-                    continue;
-                }
-                String key = trimmed.substring(0, separator).trim();
-                String value = trimmed.substring(separator + 1).trim();
-                values.put(key, value);
-            }
+        try (Stream<String> lines = Files.lines(envFile)) {
+            return KeyValueFile.parse(lines);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to read .env file", e);
         }
-        return values;
     }
 }

--- a/src/main/java/com/aicodinginterviewprep/config/EnvConfig.java
+++ b/src/main/java/com/aicodinginterviewprep/config/EnvConfig.java
@@ -1,0 +1,53 @@
+package com.aicodinginterviewprep.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class EnvConfig {
+    private static final Map<String, String> VALUES = load();
+
+    private EnvConfig() {
+    }
+
+    public static String get(String key) {
+        String envValue = System.getenv(key);
+        if (envValue != null && !envValue.isBlank()) {
+            return envValue;
+        }
+        return VALUES.get(key);
+    }
+
+    public static String get(String key, String defaultValue) {
+        String value = get(key);
+        return (value == null || value.isBlank()) ? defaultValue : value;
+    }
+
+    private static Map<String, String> load() {
+        Map<String, String> values = new HashMap<>();
+        Path envFile = Path.of(".env");
+        if (!Files.exists(envFile)) {
+            return values;
+        }
+        try {
+            for (String line : Files.readAllLines(envFile)) {
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    continue;
+                }
+                int separator = trimmed.indexOf('=');
+                if (separator <= 0) {
+                    continue;
+                }
+                String key = trimmed.substring(0, separator).trim();
+                String value = trimmed.substring(separator + 1).trim();
+                values.put(key, value);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read .env file", e);
+        }
+        return values;
+    }
+}

--- a/src/main/java/com/aicodinginterviewprep/config/KeyValueFile.java
+++ b/src/main/java/com/aicodinginterviewprep/config/KeyValueFile.java
@@ -1,0 +1,23 @@
+package com.aicodinginterviewprep.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public final class KeyValueFile {
+    private KeyValueFile() {
+    }
+
+    public static Map<String, String> parse(Stream<String> lines) {
+        Map<String, String> values = new HashMap<>();
+        lines.forEach(line -> {
+            String trimmed = line.trim();
+            int separator = trimmed.indexOf('=');
+            boolean isEntry = !trimmed.isEmpty() && !trimmed.startsWith("#") && separator > 0;
+            if (isEntry) {
+                values.put(trimmed.substring(0, separator).trim(), trimmed.substring(separator + 1).trim());
+            }
+        });
+        return values;
+    }
+}

--- a/src/main/java/com/aicodinginterviewprep/service/OpenAiQuestionService.java
+++ b/src/main/java/com/aicodinginterviewprep/service/OpenAiQuestionService.java
@@ -2,6 +2,7 @@ package com.aicodinginterviewprep.service;
 
 import com.aicodinginterviewprep.QuestionType;
 import com.aicodinginterviewprep.config.EnvConfig;
+import com.aicodinginterviewprep.config.KeyValueFile;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -16,7 +17,6 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -26,32 +26,46 @@ public class OpenAiQuestionService {
     private static final String DEFAULT_MODEL = "gpt-5-nano";
     private static final String PROMPTS_RESOURCE = "/prompts/promptengineering.txt";
     private static final int MAX_COMPLETION_TOKENS = 100;
+    private static final String CONTENT_FIELD = "content";
 
-    private final HttpClient httpClient = HttpClient.newBuilder()
-        .connectTimeout(Duration.ofSeconds(10))
-        .build();
+    private final HttpClient httpClient;
+    private final String apiKey;
+    private final String model;
+    private final Map<String, String> prompts;
+    private final Map<QuestionType, List<String>> topicsByType;
+    private final Random random;
 
-    private final Map<String, String> prompts = loadPrompts();
-    private final Map<QuestionType, List<String>> topicsByType = Map.of(
-        QuestionType.BEHAVIOURAL, extractTopics(prompts, "BEHAVIOURAL_TOPIC_"),
-        QuestionType.THEORY, extractTopics(prompts, "THEORY_TOPIC_"));
-    private final Random random = new Random();
+    public OpenAiQuestionService() {
+        this(
+            HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build(),
+            EnvConfig.get("OPENAI_API_KEY"),
+            EnvConfig.get("OPENAI_MODEL", DEFAULT_MODEL));
+    }
+
+    OpenAiQuestionService(HttpClient httpClient, String apiKey, String model) {
+        this.httpClient = httpClient;
+        this.apiKey = apiKey;
+        this.model = model;
+        this.prompts = loadPrompts();
+        this.topicsByType = Map.of(
+            QuestionType.BEHAVIOURAL, extractTopics(prompts, "BEHAVIOURAL_TOPIC_"),
+            QuestionType.THEORY, extractTopics(prompts, "THEORY_TOPIC_"));
+        this.random = new Random();
+    }
 
     public String generateQuestion(QuestionType type) throws IOException, InterruptedException {
-        String apiKey = EnvConfig.get("OPENAI_API_KEY");
         if (apiKey == null || apiKey.isBlank()) {
             throw new IllegalStateException(
                 "OPENAI_API_KEY is not set. Add it to your local .env file (see .env.example).");
         }
-        String model = EnvConfig.get("OPENAI_MODEL", DEFAULT_MODEL);
 
         JSONObject payload = new JSONObject();
         payload.put("model", model);
         payload.put("max_completion_tokens", MAX_COMPLETION_TOKENS);
         payload.put("reasoning_effort", "minimal");
         payload.put("messages", new JSONArray()
-            .put(new JSONObject().put("role", "system").put("content", prompts.get("SYSTEM")))
-            .put(new JSONObject().put("role", "user").put("content", buildUserPrompt(type))));
+            .put(new JSONObject().put("role", "system").put(CONTENT_FIELD, prompts.get("SYSTEM")))
+            .put(new JSONObject().put("role", "user").put(CONTENT_FIELD, buildUserPrompt(type))));
 
         HttpRequest request = HttpRequest.newBuilder()
             .uri(URI.create(API_URL))
@@ -72,11 +86,11 @@ public class OpenAiQuestionService {
         return json.getJSONArray("choices")
             .getJSONObject(0)
             .getJSONObject("message")
-            .getString("content")
+            .getString(CONTENT_FIELD)
             .trim();
     }
 
-    private String buildUserPrompt(QuestionType type) {
+    String buildUserPrompt(QuestionType type) {
         List<String> topics = topicsByType.get(type);
         String topic = topics.get(random.nextInt(topics.size()));
         return prompts.get(type.name() + "_TEMPLATE").replace("{topic}", topic);
@@ -91,28 +105,15 @@ public class OpenAiQuestionService {
     }
 
     private static Map<String, String> loadPrompts() {
-        Map<String, String> values = new HashMap<>();
         try (InputStream in = OpenAiQuestionService.class.getResourceAsStream(PROMPTS_RESOURCE)) {
             if (in == null) {
                 throw new IllegalStateException("Missing prompts resource: " + PROMPTS_RESOURCE);
             }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    String trimmed = line.trim();
-                    if (trimmed.isEmpty() || trimmed.startsWith("#")) {
-                        continue;
-                    }
-                    int separator = trimmed.indexOf('=');
-                    if (separator <= 0) {
-                        continue;
-                    }
-                    values.put(trimmed.substring(0, separator).trim(), trimmed.substring(separator + 1).trim());
-                }
+                return KeyValueFile.parse(reader.lines());
             }
         } catch (IOException e) {
             throw new IllegalStateException("Failed to read prompts resource: " + PROMPTS_RESOURCE, e);
         }
-        return values;
     }
 }

--- a/src/main/java/com/aicodinginterviewprep/service/OpenAiQuestionService.java
+++ b/src/main/java/com/aicodinginterviewprep/service/OpenAiQuestionService.java
@@ -1,0 +1,118 @@
+package com.aicodinginterviewprep.service;
+
+import com.aicodinginterviewprep.QuestionType;
+import com.aicodinginterviewprep.config.EnvConfig;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class OpenAiQuestionService {
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final String DEFAULT_MODEL = "gpt-5-nano";
+    private static final String PROMPTS_RESOURCE = "/prompts/promptengineering.txt";
+    private static final int MAX_COMPLETION_TOKENS = 100;
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .build();
+
+    private final Map<String, String> prompts = loadPrompts();
+    private final Map<QuestionType, List<String>> topicsByType = Map.of(
+        QuestionType.BEHAVIOURAL, extractTopics(prompts, "BEHAVIOURAL_TOPIC_"),
+        QuestionType.THEORY, extractTopics(prompts, "THEORY_TOPIC_"));
+    private final Random random = new Random();
+
+    public String generateQuestion(QuestionType type) throws IOException, InterruptedException {
+        String apiKey = EnvConfig.get("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new IllegalStateException(
+                "OPENAI_API_KEY is not set. Add it to your local .env file (see .env.example).");
+        }
+        String model = EnvConfig.get("OPENAI_MODEL", DEFAULT_MODEL);
+
+        JSONObject payload = new JSONObject();
+        payload.put("model", model);
+        payload.put("max_completion_tokens", MAX_COMPLETION_TOKENS);
+        payload.put("reasoning_effort", "minimal");
+        payload.put("messages", new JSONArray()
+            .put(new JSONObject().put("role", "system").put("content", prompts.get("SYSTEM")))
+            .put(new JSONObject().put("role", "user").put("content", buildUserPrompt(type))));
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(API_URL))
+            .timeout(Duration.ofSeconds(30))
+            .header("Authorization", "Bearer " + apiKey)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(payload.toString()))
+            .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException(
+                "OpenAI request failed (HTTP " + response.statusCode() + "): " + response.body());
+        }
+
+        JSONObject json = new JSONObject(response.body());
+        return json.getJSONArray("choices")
+            .getJSONObject(0)
+            .getJSONObject("message")
+            .getString("content")
+            .trim();
+    }
+
+    private String buildUserPrompt(QuestionType type) {
+        List<String> topics = topicsByType.get(type);
+        String topic = topics.get(random.nextInt(topics.size()));
+        return prompts.get(type.name() + "_TEMPLATE").replace("{topic}", topic);
+    }
+
+    private static List<String> extractTopics(Map<String, String> prompts, String prefix) {
+        return prompts.entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith(prefix))
+            .sorted(Comparator.comparingInt(entry -> Integer.parseInt(entry.getKey().substring(prefix.length()))))
+            .map(Map.Entry::getValue)
+            .toList();
+    }
+
+    private static Map<String, String> loadPrompts() {
+        Map<String, String> values = new HashMap<>();
+        try (InputStream in = OpenAiQuestionService.class.getResourceAsStream(PROMPTS_RESOURCE)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing prompts resource: " + PROMPTS_RESOURCE);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String trimmed = line.trim();
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                        continue;
+                    }
+                    int separator = trimmed.indexOf('=');
+                    if (separator <= 0) {
+                        continue;
+                    }
+                    values.put(trimmed.substring(0, separator).trim(), trimmed.substring(separator + 1).trim());
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read prompts resource: " + PROMPTS_RESOURCE, e);
+        }
+        return values;
+    }
+}

--- a/src/main/resources/prompts/promptengineering.txt
+++ b/src/main/resources/prompts/promptengineering.txt
@@ -1,0 +1,38 @@
+# Prompt engineering for AI question generation.
+# Format: KEY=single-line prompt text. Edit these to change what the AI generates.
+# SYSTEM applies to every request.
+# BEHAVIOURAL_TEMPLATE / THEORY_TEMPLATE are used with {topic} replaced by one
+# randomly chosen *_TOPIC_N entry per request, so questions are spread across
+# all topic areas instead of the model repeatedly picking the same favourites
+# (tested: leaving it to the model alone clustered heavily on 1-2 topics).
+
+SYSTEM=You are an interview coach generating one interview question at a time for a software engineering candidate. Respond with only the question text: a single concise sentence, no more than 25 words, no numbering, no quotes, no preamble, no answer.
+
+BEHAVIOURAL_TEMPLATE=Generate one behavioural interview question for a software engineering candidate, styled like a real interview question. Focus specifically on this topic area: {topic}.
+
+BEHAVIOURAL_TOPIC_1=Teamwork - working effectively with others, dividing tasks, supporting teammates
+BEHAVIOURAL_TOPIC_2=Conflict resolution - disagreeing with a teammate or stakeholder and resolving it productively
+BEHAVIOURAL_TOPIC_3=Handling failure - a project or task that did not go as planned and what you learned
+BEHAVIOURAL_TOPIC_4=A difficult bug - a hard-to-diagnose or hard-to-fix technical problem you worked through
+BEHAVIOURAL_TOPIC_5=Project ownership - taking a project or feature from start to finish
+BEHAVIOURAL_TOPIC_6=Leadership - leading, mentoring, or influencing others without formal authority
+BEHAVIOURAL_TOPIC_7=Deadlines - managing competing priorities or a tight deadline
+BEHAVIOURAL_TOPIC_8=Learning something new - picking up an unfamiliar technology, tool, or domain quickly
+
+THEORY_TEMPLATE=Generate one technical theory interview question for a software engineering candidate, styled like a real technical interview question rather than a textbook exercise. Focus specifically on this topic area: {topic}. Favor conceptual "what is" or "how does X work" questions over rote definitions.
+
+THEORY_TOPIC_1=Data Structures - arrays, strings, linked lists, stacks, queues, hash maps, sets, trees, heaps, graphs
+THEORY_TOPIC_2=Algorithms - searching, sorting, recursion, BFS/DFS, two pointers, binary search, basic greedy algorithms, basic dynamic programming
+THEORY_TOPIC_3=Complexity - Big-O, time vs space complexity, comparing algorithms, recognizing O(1), O(n), O(log n), O(n^2)
+THEORY_TOPIC_4=Operating Systems - processes vs threads, concurrency, context switching, virtual memory, paging, deadlocks, scheduling, mutexes/semaphores
+THEORY_TOPIC_5=Computer Networks - TCP vs UDP, IP, DNS, HTTP/HTTPS, ports, packets, routers, client-server model, what happens when you enter a URL
+THEORY_TOPIC_6=Cybersecurity - authentication vs authorization, hashing vs encryption, SQL injection, XSS, HTTPS/TLS, common vulnerabilities, least privilege, basic network security
+THEORY_TOPIC_7=Databases / SQL - SQL queries, joins, primary/foreign keys, indexes, normalization, transactions, ACID, relational vs NoSQL
+THEORY_TOPIC_8=OOP - classes/objects, inheritance, encapsulation, abstraction, polymorphism, interfaces, composition
+THEORY_TOPIC_9=Programming Fundamentals - variables, loops, functions, references/pointers, memory, exceptions, scope, pass-by-value/reference, language-specific concepts
+THEORY_TOPIC_10=Software Engineering - git, testing, debugging, APIs, REST, CI/CD basics, Agile, code reviews, clean code
+THEORY_TOPIC_11=Computer Architecture - CPU, RAM, cache, registers, stack vs heap, binary/hex, compilation, how programs execute
+THEORY_TOPIC_12=Web Development - frontend vs backend, HTTP methods, REST APIs, cookies, sessions, JSON, status codes, basic browser/server interaction
+THEORY_TOPIC_13=System Design - designing a simple URL shortener, chat app, API, database schema, caching, scalability concepts, kept basic for students
+THEORY_TOPIC_14=Cloud / DevOps - containers, Docker, VMs, cloud computing, deployment, load balancing fundamentals
+THEORY_TOPIC_15=AI / ML - training vs testing, overfitting, classification vs regression, neural network basics

--- a/src/test/java/com/aicodinginterviewprep/QuestionTypeTest.java
+++ b/src/test/java/com/aicodinginterviewprep/QuestionTypeTest.java
@@ -1,0 +1,19 @@
+package com.aicodinginterviewprep;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QuestionTypeTest {
+
+    @Test
+    void hasBehaviouralAndTheoryValues() {
+        assertEquals(2, QuestionType.values().length);
+    }
+
+    @Test
+    void toStringReturnsHumanReadableLabel() {
+        assertEquals("Behavioural", QuestionType.BEHAVIOURAL.toString());
+        assertEquals("Theory", QuestionType.THEORY.toString());
+    }
+}

--- a/src/test/java/com/aicodinginterviewprep/config/EnvConfigTest.java
+++ b/src/test/java/com/aicodinginterviewprep/config/EnvConfigTest.java
@@ -1,0 +1,21 @@
+package com.aicodinginterviewprep.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class EnvConfigTest {
+
+    private static final String UNSET_KEY = "SOFTENG310_TEST_KEY_THAT_DOES_NOT_EXIST";
+
+    @Test
+    void getReturnsNullWhenKeyIsNotSetAnywhere() {
+        assertNull(EnvConfig.get(UNSET_KEY));
+    }
+
+    @Test
+    void getWithDefaultReturnsDefaultWhenKeyIsNotSetAnywhere() {
+        assertEquals("fallback", EnvConfig.get(UNSET_KEY, "fallback"));
+    }
+}

--- a/src/test/java/com/aicodinginterviewprep/config/KeyValueFileTest.java
+++ b/src/test/java/com/aicodinginterviewprep/config/KeyValueFileTest.java
@@ -1,0 +1,64 @@
+package com.aicodinginterviewprep.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KeyValueFileTest {
+
+    @Test
+    void parsesSimpleKeyValuePairs() {
+        Map<String, String> values = KeyValueFile.parse(Stream.of("FOO=bar", "BAZ=qux"));
+
+        assertEquals("bar", values.get("FOO"));
+        assertEquals("qux", values.get("BAZ"));
+    }
+
+    @Test
+    void trimsWhitespaceAroundKeysAndValues() {
+        Map<String, String> values = KeyValueFile.parse(Stream.of("  FOO  =  bar  "));
+
+        assertEquals("bar", values.get("FOO"));
+    }
+
+    @Test
+    void skipsBlankLinesAndComments() {
+        Map<String, String> values = KeyValueFile.parse(Stream.of("", "   ", "# a comment", "FOO=bar"));
+
+        assertEquals(1, values.size());
+        assertEquals("bar", values.get("FOO"));
+    }
+
+    @Test
+    void skipsLinesWithoutAnEqualsSign() {
+        Map<String, String> values = KeyValueFile.parse(Stream.of("NOT_A_PAIR", "FOO=bar"));
+
+        assertEquals(1, values.size());
+        assertTrue(values.containsKey("FOO"));
+    }
+
+    @Test
+    void skipsLinesWhereEqualsIsTheFirstCharacter() {
+        Map<String, String> values = KeyValueFile.parse(Stream.of("=novalue", "FOO=bar"));
+
+        assertEquals(1, values.size());
+    }
+
+    @Test
+    void valueCanContainAnEqualsSign() {
+        Map<String, String> values = KeyValueFile.parse(Stream.of("FOO=bar=baz"));
+
+        assertEquals("bar=baz", values.get("FOO"));
+    }
+
+    @Test
+    void emptyStreamProducesEmptyMap() {
+        Map<String, String> values = KeyValueFile.parse(Stream.empty());
+
+        assertTrue(values.isEmpty());
+    }
+}

--- a/src/test/java/com/aicodinginterviewprep/service/OpenAiQuestionServiceTest.java
+++ b/src/test/java/com/aicodinginterviewprep/service/OpenAiQuestionServiceTest.java
@@ -1,0 +1,98 @@
+package com.aicodinginterviewprep.service;
+
+import com.aicodinginterviewprep.QuestionType;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OpenAiQuestionServiceTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void generateQuestionReturnsTrimmedContentFromA200Response() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(
+            "{\"choices\":[{\"message\":{\"content\":\"  What is a hash map?  \"}}]}");
+        when(httpClient.<String>send(any(HttpRequest.class), any())).thenReturn(response);
+
+        OpenAiQuestionService service = new OpenAiQuestionService(httpClient, "fake-key", "gpt-5-nano");
+
+        assertEquals("What is a hash map?", service.generateQuestion(QuestionType.THEORY));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void generateQuestionThrowsOnNon200Response() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(403);
+        when(response.body()).thenReturn("{\"error\":\"forbidden\"}");
+        when(httpClient.<String>send(any(HttpRequest.class), any())).thenReturn(response);
+
+        OpenAiQuestionService service = new OpenAiQuestionService(httpClient, "fake-key", "gpt-5-nano");
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+            () -> service.generateQuestion(QuestionType.BEHAVIOURAL));
+        assertTrue(exception.getMessage().contains("403"));
+    }
+
+    @Test
+    void generateQuestionThrowsWhenApiKeyIsMissing() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), null, "gpt-5-nano");
+
+        assertThrows(IllegalStateException.class, () -> service.generateQuestion(QuestionType.THEORY));
+    }
+
+    @Test
+    void generateQuestionThrowsWhenApiKeyIsBlank() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "   ", "gpt-5-nano");
+
+        assertThrows(IllegalStateException.class, () -> service.generateQuestion(QuestionType.THEORY));
+    }
+
+    @Test
+    void buildUserPromptFillsInATheoryTopicArea() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        String prompt = service.buildUserPrompt(QuestionType.THEORY);
+
+        assertTrue(prompt.contains("Focus specifically on this topic area:"));
+    }
+
+    @Test
+    void buildUserPromptRotatesAcrossMultipleBehaviouralTopics() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            seen.add(service.buildUserPrompt(QuestionType.BEHAVIOURAL));
+        }
+
+        assertTrue(seen.size() > 1, "expected topic rotation to produce more than one distinct prompt");
+    }
+
+    @Test
+    void buildUserPromptRotatesAcrossMultipleTheoryTopics() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            seen.add(service.buildUserPrompt(QuestionType.THEORY));
+        }
+
+        assertTrue(seen.size() > 1, "expected topic rotation to produce more than one distinct prompt");
+    }
+}


### PR DESCRIPTION
Closes #12

Wires the Practice tab's "Generate New Question" button to OpenAI so it produces behavioural or theory interview questions on demand.

## What's in this PR
- `.env` support for `OPENAI_API_KEY` / `OPENAI_MODEL`, gitignored so the key never lands in the repo (`.env.example` shows teammates what to set)
- `OpenAiQuestionService`: calls OpenAI's chat completions API with `gpt-5-nano`, using `reasoning_effort=minimal` and a token cap so questions come back short and cheap
- `promptengineering.txt`: prompt text lives in a resource file, not hardcoded in Java, so it's easy to tune
- 15 theory topic areas and 8 behavioural topic areas, each picked at random per request — without this, testing showed the model clustering heavily on 1-2 favourite topics (e.g. 6/8 behavioural questions were all "disagreed with a teammate" variants)
- Practice tab: Behavioural/Theory dropdown, and the API call runs on a background thread so the UI doesn't freeze while waiting on a response

## Test plan
- [x] `mvnw compile` / `mvnw test` pass
- [x] Verified live against the team's OpenAI key: both question types return distinct, on-topic questions
- [x] Verified topic rotation empirically (8+ generations per type, spread across categories, no clustering)
- [x] Manual click-through of the Practice tab UI (not yet done by a reviewer)