### PR TITLE
Stop contributors from forking; guard SonarCloud against fork PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Reject fork pull requests
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::This PR comes from a fork (${{ github.event.pull_request.head.repo.full_name }}). GitHub does not pass repository secrets to fork PRs, so SonarCloud cannot authenticate here."
+          echo "::error::All team members have push access to this repo — push your branch here directly instead of from a personal fork. See CONTRIBUTING.md."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing to AI Coding Interview Prep.
 
 ## How to contribute
 
-1. Fork the repository.
+1. Clone this repository directly — do not fork it. All team members have push access, and PRs opened from a personal fork do not receive the `SONAR_TOKEN` secret, so SonarCloud fails on them (see #14).
 2. Create a branch for your change: `git checkout -b feature-name`.
 3. Make small, focused commits.
 4. Push your branch to GitHub.

--- a/WIKI.md
+++ b/WIKI.md
@@ -37,3 +37,5 @@ AI Coding Interview Prep is an AI-supported interview preparation tool that help
 ## Workflow Notes
 
 While getting the SonarCloud and Snyk CI pipelines working (fixing auth tokens, the quality gate, and mvnw permissions), a handful of commits were pushed straight to main instead of going through an issue, feature branch, and reviewed pull request. This was a mistake made early on while we were still nailing down the required workflow. From this point on, all contributions go through: open/approve an issue -> feature branch off main -> PR referencing the issue -> review by another team member -> squash and merge. See #6.
+
+PR #14 was opened from a personal fork instead of a branch on this repo. GitHub does not pass repository secrets (`SONAR_TOKEN`, `SONAR_PROJECT_KEY`, `SONAR_ORGANIZATION`) to workflows triggered by pull requests from forks, so the SonarCloud check failed with an "Not authorized / empty project key" error even though the code itself was fine. All team members already have push access to this repo, so branches should be pushed here directly rather than from a fork — see the updated CONTRIBUTING.md.


### PR DESCRIPTION
Fork PRs don't receive repo secrets, so SonarCloud auth fails (see #14). All team members already have push access, so forking isn't needed.

- CONTRIBUTING.md: clone and branch directly instead of forking
- WIKI.md: note the incident
- sonarcloud.yml: fail fast with a clear message on fork PRs

Closes #18