### PR TITLE
Remove stray editor lock file

### DIFF
--- a/src/test/java/com/aicodinginterviewprep/coding/.LCKCodingQuestionBankTest.java~
+++ b/src/test/java/com/aicodinginterviewprep/coding/.LCKCodingQuestionBankTest.java~
@@ -1,1 +1,0 @@
-C:\Users\liddl\OneDrive\Desktop\Softeng310\AI-Coding-Interview-Prep\src\test\java\com\aicodinginterviewprep\coding\CodingQuestionBankTest.java


### PR DESCRIPTION
## Summary
- Removes .LCKCodingQuestionBankTest.java~, a NetBeans lock file that got committed by accident in #28

Fixes #30

## Test plan
- No code changes, just a file deletion, ran the existing test suite to confirm nothing references it