### PR TITLE
Add LeetCode practice tab and redesign home/login screens

### DIFF
--- a/src/main/java/com/aicodinginterviewprep/QuestionType.java
+++ b/src/main/java/com/aicodinginterviewprep/QuestionType.java
@@ -2,7 +2,8 @@ package com.aicodinginterviewprep;
 
 public enum QuestionType {
     BEHAVIOURAL("Behavioural"),
-    THEORY("Theory");
+    THEORY("Theory"),
+    CODING("Coding");
 
     private final String label;
 

--- a/src/main/java/com/aicodinginterviewprep/SceneManager.java
+++ b/src/main/java/com/aicodinginterviewprep/SceneManager.java
@@ -26,6 +26,7 @@ public class SceneManager {
         sceneMap.put("home", "/fxml/Home.fxml");
         sceneMap.put("authentication", "/fxml/Authentication.fxml");
         sceneMap.put("practice", "/fxml/Practice.fxml");
+        sceneMap.put("coding", "/fxml/Coding.fxml");
         sceneMap.put("feedback", "/fxml/Feedback.fxml");
     }
 

--- a/src/main/java/com/aicodinginterviewprep/controllers/AuthController.java
+++ b/src/main/java/com/aicodinginterviewprep/controllers/AuthController.java
@@ -4,9 +4,12 @@ import com.aicodinginterviewprep.Authenticator;
 import com.aicodinginterviewprep.SceneAware;
 import com.aicodinginterviewprep.SceneManager;
 import javafx.scene.control.Button;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 import java.io.IOException;
 
@@ -15,18 +18,54 @@ public class AuthController implements SceneAware {
 
     private SceneManager sceneManager;
     private Authenticator authenticator;
+    private boolean passwordVisible = false;
 
     public PasswordField passwordfieldPassword;
+    public TextField textfieldPasswordVisible;
     public TextField textfieldUsername;
     public Button buttonLogIn;
     public Button buttonSignUp;
     public Button buttonReturn;
+    public Hyperlink linkTogglePassword;
     public Label labelMessage;
 
     @Override
     public void setSceneManager(SceneManager sceneManager) {
         this.sceneManager = sceneManager;
         this.authenticator = new Authenticator(ACCOUNTS_FILE);
+        textfieldPasswordVisible.textProperty().bindBidirectional(passwordfieldPassword.textProperty());
+        textfieldPasswordVisible.setVisible(false);
+        textfieldPasswordVisible.setManaged(false);
+        linkTogglePassword.setText("Show");
+
+        textfieldUsername.setOnKeyPressed(this::focusPasswordFieldOnTab);
+        passwordfieldPassword.setOnKeyPressed(this::focusTogglePasswordOnTab);
+        textfieldPasswordVisible.setOnKeyPressed(this::focusTogglePasswordOnTab);
+    }
+
+    private void focusPasswordFieldOnTab(KeyEvent event) {
+        if (event.getCode() == KeyCode.TAB && !event.isShiftDown()) {
+            event.consume();
+            (passwordVisible ? textfieldPasswordVisible : passwordfieldPassword).requestFocus();
+        }
+    }
+
+    private void focusTogglePasswordOnTab(KeyEvent event) {
+        if (event.getCode() == KeyCode.TAB && !event.isShiftDown()) {
+            event.consume();
+            linkTogglePassword.requestFocus();
+        }
+    }
+
+    public void onTogglePasswordVisibility() {
+        passwordVisible = !passwordVisible;
+
+        passwordfieldPassword.setVisible(!passwordVisible);
+        passwordfieldPassword.setManaged(!passwordVisible);
+        textfieldPasswordVisible.setVisible(passwordVisible);
+        textfieldPasswordVisible.setManaged(passwordVisible);
+
+        linkTogglePassword.setText(passwordVisible ? "Hide" : "Show");
     }
 
     public void onPassword() {
@@ -75,6 +114,12 @@ public class AuthController implements SceneAware {
     }
 
     public void onReturn() {
+        textfieldUsername.clear();
+        passwordfieldPassword.clear();
+        labelMessage.setText("");
+        if (passwordVisible) {
+            onTogglePasswordVisibility();
+        }
         sceneManager.switchToScene("home");
     }
 }

--- a/src/main/java/com/aicodinginterviewprep/controllers/CodingController.java
+++ b/src/main/java/com/aicodinginterviewprep/controllers/CodingController.java
@@ -7,42 +7,39 @@ import com.aicodinginterviewprep.service.OpenAiQuestionService;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.BorderPane;
 
-public class PracticeController implements SceneAware {
+public class CodingController implements SceneAware {
+    private static final String STARTER_CODE = "// Write your code here";
+
     private final OpenAiQuestionService questionService = new OpenAiQuestionService();
     private SceneManager sceneManager;
 
-    public BorderPane practiceRoot;
+    public BorderPane codingRoot;
     public TextArea questionOutput;
-    public TextArea answerInput;
+    public TextArea codeEditor;
 
     @FXML public Button buttonReturn;
     @FXML public Button buttonSubmitAnswer;
     @FXML public Button buttonGenerateQuestion;
-    @FXML public Button buttonCodingPractice;
-    @FXML public ComboBox<QuestionType> comboQuestionType;
+    @FXML public Button buttonPractice;
 
     @Override
     public void setSceneManager(SceneManager sceneManager) {
         this.sceneManager = sceneManager;
-        this.comboQuestionType.getItems().addAll(QuestionType.BEHAVIOURAL, QuestionType.THEORY);
-        this.comboQuestionType.setValue(QuestionType.BEHAVIOURAL);
     }
 
     @FXML
     public void onGenerateQuestion() {
-        QuestionType type = comboQuestionType.getValue();
         buttonGenerateQuestion.setDisable(true);
         questionOutput.setText("Generating question...");
-        answerInput.clear();
+        codeEditor.setText(STARTER_CODE);
 
         Task<String> task = new Task<>() {
             @Override
             protected String call() throws Exception {
-                return questionService.generateQuestion(type);
+                return questionService.generateQuestion(QuestionType.CODING);
             }
         };
 
@@ -58,7 +55,7 @@ public class PracticeController implements SceneAware {
             buttonGenerateQuestion.setDisable(false);
         });
 
-        Thread worker = new Thread(task, "openai-question-generation");
+        Thread worker = new Thread(task, "openai-coding-question-generation");
         worker.setDaemon(true);
         worker.start();
     }
@@ -71,8 +68,8 @@ public class PracticeController implements SceneAware {
         sceneManager.switchToScene("home");
     }
 
-    public void onCodingPractice() {
-        sceneManager.switchToScene("coding");
+    public void onPractice() {
+        sceneManager.switchToScene("practice");
     }
 
     public void runEvaluation() {
@@ -81,7 +78,7 @@ public class PracticeController implements SceneAware {
         if (!(controller instanceof FeedbackController feedbackController)) {
             return;
         }
-        feedbackController.setAnswerControls(questionOutput, null, answerInput, "practice");
+        feedbackController.setAnswerControls(questionOutput, codeEditor, null, "coding");
         feedbackController.runEvaluation();
     }
 }

--- a/src/main/java/com/aicodinginterviewprep/controllers/FeedbackController.java
+++ b/src/main/java/com/aicodinginterviewprep/controllers/FeedbackController.java
@@ -15,12 +15,12 @@ public class FeedbackController implements SceneAware {
 
     public TextArea textareaEvaluation;
     public Button buttonTryAgain;
-    public Button buttonSubmitAnswer;
 
-    // References to Practice tab controls for answer extraction
+    // References to the originating tab's controls for answer extraction
     private TextArea questionOutput;
     private TextArea codeEditor;
     private TextInputControl answerInput;
+    private String returnScene = "practice";
 
     @Override
     public void setSceneManager(SceneManager sceneManager) {
@@ -28,13 +28,19 @@ public class FeedbackController implements SceneAware {
     }
 
     public void setAnswerControls(TextArea questionOutput, TextArea codeEditor, TextInputControl answerInput) {
+        setAnswerControls(questionOutput, codeEditor, answerInput, "practice");
+    }
+
+    public void setAnswerControls(
+        TextArea questionOutput, TextArea codeEditor, TextInputControl answerInput, String returnScene) {
         this.questionOutput = questionOutput;
         this.codeEditor = codeEditor;
         this.answerInput = answerInput;
+        this.returnScene = returnScene;
     }
 
     public void onTryAgain() {
-        sceneManager.switchToScene("practice");
+        sceneManager.switchToScene(returnScene);
     }
 
     public void runEvaluation() {
@@ -97,9 +103,6 @@ public class FeedbackController implements SceneAware {
     }
 
     private void setEvaluationInProgress(boolean inProgress) {
-        if (buttonSubmitAnswer != null) {
-            buttonSubmitAnswer.setDisable(inProgress);
-        }
         if (buttonTryAgain != null) {
             buttonTryAgain.setDisable(inProgress);
         }

--- a/src/main/java/com/aicodinginterviewprep/controllers/HomeController.java
+++ b/src/main/java/com/aicodinginterviewprep/controllers/HomeController.java
@@ -9,7 +9,6 @@ public class HomeController implements SceneAware {
     private SceneManager sceneManager;
 
     @FXML public Button buttonGetStarted;
-    @FXML public Button buttonSignIn;
 
     @Override
     public void setSceneManager(SceneManager sceneManager) {
@@ -18,11 +17,6 @@ public class HomeController implements SceneAware {
 
     @FXML
     public void onGetStarted() {
-        sceneManager.switchToScene("practice");
-    }
-
-    @FXML
-    public void onSignIn() {
         sceneManager.switchToScene("authentication");
     }
 }

--- a/src/main/java/com/aicodinginterviewprep/service/OpenAiQuestionService.java
+++ b/src/main/java/com/aicodinginterviewprep/service/OpenAiQuestionService.java
@@ -26,7 +26,9 @@ public class OpenAiQuestionService {
     private static final String DEFAULT_MODEL = "gpt-5-nano";
     private static final String PROMPTS_RESOURCE = "/prompts/promptengineering.txt";
     private static final int MAX_COMPLETION_TOKENS = 100;
+    private static final int MAX_COMPLETION_TOKENS_CODING = 450;
     private static final String CONTENT_FIELD = "content";
+    private static final List<String> CODING_DIFFICULTIES = List.of("Easy", "Medium", "Hard");
 
     private final HttpClient httpClient;
     private final String apiKey;
@@ -49,7 +51,8 @@ public class OpenAiQuestionService {
         this.prompts = loadPrompts();
         this.topicsByType = Map.of(
             QuestionType.BEHAVIOURAL, extractTopics(prompts, "BEHAVIOURAL_TOPIC_"),
-            QuestionType.THEORY, extractTopics(prompts, "THEORY_TOPIC_"));
+            QuestionType.THEORY, extractTopics(prompts, "THEORY_TOPIC_"),
+            QuestionType.CODING, extractTopics(prompts, "CODING_TOPIC_"));
         this.random = new Random();
     }
 
@@ -61,10 +64,10 @@ public class OpenAiQuestionService {
 
         JSONObject payload = new JSONObject();
         payload.put("model", model);
-        payload.put("max_completion_tokens", MAX_COMPLETION_TOKENS);
+        payload.put("max_completion_tokens", maxCompletionTokensFor(type));
         payload.put("reasoning_effort", "minimal");
         payload.put("messages", new JSONArray()
-            .put(new JSONObject().put("role", "system").put(CONTENT_FIELD, prompts.get("SYSTEM")))
+            .put(new JSONObject().put("role", "system").put(CONTENT_FIELD, systemPromptFor(type)))
             .put(new JSONObject().put("role", "user").put(CONTENT_FIELD, buildUserPrompt(type))));
 
         HttpRequest request = HttpRequest.newBuilder()
@@ -90,10 +93,25 @@ public class OpenAiQuestionService {
             .trim();
     }
 
+    String systemPromptFor(QuestionType type) {
+        return prompts.getOrDefault(type.name() + "_SYSTEM", prompts.get("SYSTEM"));
+    }
+
+    int maxCompletionTokensFor(QuestionType type) {
+        return type == QuestionType.CODING ? MAX_COMPLETION_TOKENS_CODING : MAX_COMPLETION_TOKENS;
+    }
+
     String buildUserPrompt(QuestionType type) {
         List<String> topics = topicsByType.get(type);
         String topic = topics.get(random.nextInt(topics.size()));
-        return prompts.get(type.name() + "_TEMPLATE").replace("{topic}", topic);
+        String template = prompts.get(type.name() + "_TEMPLATE").replace("{topic}", topic);
+
+        if (type == QuestionType.CODING) {
+            String difficulty = CODING_DIFFICULTIES.get(random.nextInt(CODING_DIFFICULTIES.size()));
+            template = template.replace("{difficulty}", difficulty);
+        }
+
+        return template;
     }
 
     private static List<String> extractTopics(Map<String, String> prompts, String prefix) {

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -158,7 +158,7 @@
     -fx-faint-focus-color: transparent;
 }
 
-.underline-field:focused {
+.underline-field:focused { /* NOSONAR: :focused is JavaFX CSS's real pseudo-class, not a typo of the web CSS :focus */
     -fx-border-color: transparent transparent #c67139 transparent;
 }
 

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -14,7 +14,7 @@
     -fx-background-color: -color-bg;
     -fx-text-fill: -color-text;
     -fx-font-family: "Figtree", "Segoe UI", sans-serif;
-    -fx-font-size: 15px;
+    -fx-font-size: 17px;
 }
 
 /* ---------- Panes ----------- */
@@ -60,13 +60,19 @@
 }
 
 .title-label {
-    -fx-font-size: 28px;
+    -fx-font-size: 30px;
     -fx-font-weight: bold;
     -fx-text-fill: #292522;
 }
 
 .error-label {
     -fx-text-fill: #b3261e;
+}
+
+.section-label {
+    -fx-font-size: 20px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #292522;
 }
 
 
@@ -93,6 +99,10 @@
     -fx-background-color: #fffdf9;
 }
 
+.question-label {
+    -fx-font-size: 18px;
+}
+
 /* ---------- Text Fields ---------- */
 
 .text-field {
@@ -111,6 +121,52 @@
     -fx-faint-focus-color: transparent;
 }
 
+/* ---------- Auth form ---------- */
+
+.auth-card {
+    -fx-background-color: #fffdf9;
+    -fx-background-radius: 18px;
+    -fx-border-color: #ded6cc;
+    -fx-border-width: 1px;
+    -fx-border-radius: 18px;
+    -fx-padding: 40px 48px;
+}
+
+.auth-title {
+    -fx-font-size: 34px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #292522;
+}
+
+.field-label {
+    -fx-font-size: 16px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #443b35;
+}
+
+.underline-field {
+    -fx-background-color: transparent;
+    -fx-background-insets: 0;
+    -fx-background-radius: 0;
+    -fx-border-color: transparent transparent #c9bfae transparent;
+    -fx-border-width: 0 0 2px 0;
+    -fx-border-radius: 0;
+    -fx-padding: 8px 2px;
+    -fx-font-size: 18px;
+    -fx-max-width: infinity;
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent;
+}
+
+.underline-field:focused {
+    -fx-border-color: transparent transparent #c67139 transparent;
+}
+
+.toggle-link {
+    -fx-font-size: 15px;
+    -fx-text-fill: #c67139;
+}
+
 /* ---------- Buttons ---------- */
 
 .button {
@@ -122,9 +178,8 @@
     -fx-border-radius: 7px;
     -fx-background-insets: 2px;
 
-    -fx-padding: 9px 18px;
-    -fx-max-width: 220px;
-    -fx-font-size: 14px;
+    -fx-padding: 10px 20px;
+    -fx-font-size: 16px;
     -fx-font-weight: bold;
 
     -fx-cursor: hand;

--- a/src/main/resources/fxml/Authentication.fxml
+++ b/src/main/resources/fxml/Authentication.fxml
@@ -2,13 +2,15 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.PasswordField?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Font?>
 
 <BorderPane prefHeight="720" prefWidth="1024" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/24.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.aicodinginterviewprep.controllers.AuthController">
    <padding>
@@ -18,22 +20,34 @@
       <Button fx:id="buttonReturn" mnemonicParsing="false" onAction="#onReturn" text="Return" />
    </top>
    <center>
-      <VBox alignment="CENTER" spacing="15">
-         <padding>
-            <Insets bottom="50" left="100" right="100" top="50" />
-         </padding>
-         <Label alignment="CENTER" styleClass="title-label" text="Log In or Sign Up">
-            <font>
-               <Font name="Bodoni MT" size="30.0" />
-            </font>
-         </Label>
-         <TextField fx:id="textfieldUsername" onAction="#onUsername" prefHeight="35.0" promptText="username" />
-         <PasswordField fx:id="passwordfieldPassword" onAction="#onPassword" prefHeight="35.0" promptText="password" />
-         <HBox alignment="CENTER" spacing="15">
-            <Button fx:id="buttonLogIn" mnemonicParsing="false" onAction="#onLogIn" prefHeight="33.0" prefWidth="85.0" text="Log In" />
-            <Button fx:id="buttonSignUp" mnemonicParsing="false" onAction="#onSignUp" prefHeight="41.0" prefWidth="117.0" text="Sign Up" />
-         </HBox>
-         <Label fx:id="labelMessage" alignment="CENTER" styleClass="error-label" wrapText="true" />
+      <VBox alignment="CENTER">
+         <VBox spacing="24" styleClass="auth-card">
+            <Label styleClass="auth-title" text="Log In or Sign Up" />
+
+            <VBox spacing="8">
+               <Label styleClass="field-label" text="Username" />
+               <TextField fx:id="textfieldUsername" onAction="#onUsername" prefHeight="46.0" prefWidth="420.0" promptText="Enter your username" styleClass="underline-field" />
+            </VBox>
+
+            <VBox spacing="8">
+               <HBox alignment="CENTER_LEFT" prefWidth="420.0">
+                  <Label styleClass="field-label" text="Password" />
+                  <Region HBox.hgrow="ALWAYS" />
+                  <Hyperlink fx:id="linkTogglePassword" onAction="#onTogglePasswordVisibility" styleClass="toggle-link" text="Show" />
+               </HBox>
+               <StackPane>
+                  <PasswordField fx:id="passwordfieldPassword" onAction="#onPassword" prefHeight="46.0" prefWidth="420.0" promptText="Enter your password" styleClass="underline-field" />
+                  <TextField fx:id="textfieldPasswordVisible" managed="false" onAction="#onPassword" prefHeight="46.0" prefWidth="420.0" promptText="Enter your password" styleClass="underline-field" visible="false" />
+               </StackPane>
+            </VBox>
+
+            <HBox spacing="15">
+               <Button fx:id="buttonLogIn" mnemonicParsing="false" onAction="#onLogIn" prefHeight="46.0" prefWidth="150.0" text="Log In" />
+               <Button fx:id="buttonSignUp" mnemonicParsing="false" onAction="#onSignUp" prefHeight="46.0" prefWidth="150.0" text="Sign Up" />
+            </HBox>
+
+            <Label fx:id="labelMessage" styleClass="error-label" wrapText="true" />
+         </VBox>
       </VBox>
    </center>
 </BorderPane>

--- a/src/main/resources/fxml/Coding.fxml
+++ b/src/main/resources/fxml/Coding.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.BorderPane?>
@@ -10,7 +9,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<BorderPane fx:id="practiceRoot" prefHeight="760" prefWidth="1200" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/24.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.aicodinginterviewprep.controllers.PracticeController">
+<BorderPane fx:id="codingRoot" prefHeight="760" prefWidth="1200" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/24.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.aicodinginterviewprep.controllers.CodingController">
 
    <padding>
       <Insets bottom="16" left="16" right="16" top="16" />
@@ -20,25 +19,25 @@
       <Button fx:id="buttonReturn" mnemonicParsing="false" onAction="#onReturn" text="Return" />
    </top>
 
-   <!-- ===== Question output ===== -->
+   <!-- ===== LeetCode-style question output ===== -->
    <left>
       <VBox>
          <padding>
             <Insets bottom="8" left="8" right="8" top="8" />
          </padding>
          <Label styleClass="section-label" text="Question" />
-         <TextArea fx:id="questionOutput" editable="false" prefHeight="634.0" prefRowCount="8" prefWidth="400.0" promptText="Generate a question to begin." styleClass="question-label" wrapText="true" VBox.vgrow="ALWAYS" />
+         <TextArea fx:id="questionOutput" editable="false" prefHeight="634.0" prefRowCount="8" prefWidth="400.0" promptText="Generate a coding question to begin." styleClass="question-label" wrapText="true" VBox.vgrow="ALWAYS" />
       </VBox>
    </left>
 
-   <!-- ===== Explanation (fills the remaining space) ===== -->
+   <!-- ===== Code editor (fills the remaining space) ===== -->
    <center>
       <VBox>
          <padding>
             <Insets bottom="8" left="8" right="8" top="8" />
          </padding>
-         <Label styleClass="section-label" text="Your explanation" />
-         <TextArea fx:id="answerInput" prefHeight="633.0" prefRowCount="20" promptText="Explain your solution" wrapText="true" VBox.vgrow="ALWAYS" />
+         <Label styleClass="section-label" text="Code editor" />
+         <TextArea fx:id="codeEditor" prefHeight="633.0" prefRowCount="20" text="// Write your code here" wrapText="true" VBox.vgrow="ALWAYS" />
       </VBox>
    </center>
 
@@ -48,9 +47,8 @@
          <padding>
             <Insets left="8" right="8" top="12" />
          </padding>
-         <ComboBox fx:id="comboQuestionType" prefWidth="260" />
          <Button fx:id="buttonGenerateQuestion" onAction="#onGenerateQuestion" text="Generate new question" />
-         <Button fx:id="buttonCodingPractice" onAction="#onCodingPractice" text="LeetCode Practice" />
+         <Button fx:id="buttonPractice" onAction="#onPractice" text="Behavioural / Theory Practice" />
          <Region HBox.hgrow="ALWAYS" />
          <Button fx:id="buttonSubmitAnswer" onAction="#onSubmitAnswer" text="Submit answer" />
       </HBox>

--- a/src/main/resources/fxml/Feedback.fxml
+++ b/src/main/resources/fxml/Feedback.fxml
@@ -25,8 +25,7 @@
          </Label>
          <TextArea fx:id="textareaEvaluation" editable="false" prefRowCount="12" wrapText="true" VBox.vgrow="ALWAYS" />
          <HBox alignment="CENTER" spacing="15">
-            <Button fx:id="buttonTryAgain" mnemonicParsing="false" onAction="#onTryAgain" prefHeight="42.0" prefWidth="206.0" text="Try Another Question" />
-            <Button fx:id="buttonSubmitAnswer" mnemonicParsing="false" prefHeight="41.0" prefWidth="160.0" text="Submit Answer" />
+            <Button fx:id="buttonTryAgain" mnemonicParsing="false" onAction="#onTryAgain" prefHeight="42.0" prefWidth="260.0" text="Try Another Question" />
          </HBox>
       </VBox>
    </center>

--- a/src/main/resources/fxml/Home.fxml
+++ b/src/main/resources/fxml/Home.fxml
@@ -23,8 +23,7 @@
          <Label alignment="CENTER" text="Go to Practice to answer coding questions and receive AI feedback." wrapText="true" />
          <Label alignment="CENTER" text="Login or register to save progress in later assignments." wrapText="true" />
          <HBox alignment="CENTER" spacing="20">
-            <Button fx:id="buttonGetStarted" mnemonicParsing="false" onAction="#onGetStarted" prefHeight="41.0" prefWidth="133.0" text="Get Started!" />
-            <Button fx:id="buttonSignIn" mnemonicParsing="false" onAction="#onSignIn" prefHeight="32.0" prefWidth="111.0" text="Sign In" />
+            <Button fx:id="buttonGetStarted" mnemonicParsing="false" onAction="#onGetStarted" prefHeight="41.0" prefWidth="165.0" text="Get Started!" />
          </HBox>
       </VBox>
    </children>

--- a/src/main/resources/prompts/promptengineering.txt
+++ b/src/main/resources/prompts/promptengineering.txt
@@ -36,3 +36,18 @@ THEORY_TOPIC_12=Web Development - frontend vs backend, HTTP methods, REST APIs, 
 THEORY_TOPIC_13=System Design - designing a simple URL shortener, chat app, API, database schema, caching, scalability concepts, kept basic for students
 THEORY_TOPIC_14=Cloud / DevOps - containers, Docker, VMs, cloud computing, deployment, load balancing fundamentals
 THEORY_TOPIC_15=AI / ML - training vs testing, overfitting, classification vs regression, neural network basics
+
+CODING_SYSTEM=You are an interview coach generating one LeetCode-style coding interview question at a time for a software engineering candidate. Follow the requested output format exactly and do not skip any of its fields. Do not include a solution, code, or markdown formatting.
+
+CODING_TEMPLATE=Generate one LeetCode-style coding interview question for a software engineering candidate, at exactly {difficulty} difficulty. Focus specifically on this topic area: {topic}. Respond in exactly this format with no extra commentary: first line 'Title: <short title>', second line 'Difficulty: {difficulty}', then a blank line, then a clear problem description, then a blank line, then a line 'Example:' followed by a line 'Input: <example input>' and a line 'Output: <example output>'.
+
+CODING_TOPIC_1=Arrays and strings - two pointers, sliding window, prefix sums, in-place manipulation
+CODING_TOPIC_2=Hash maps and sets - frequency counting, lookups, grouping, deduplication
+CODING_TOPIC_3=Linked lists - traversal, reversal, cycle detection, merging
+CODING_TOPIC_4=Stacks and queues - matching brackets, monotonic stacks, queue-based simulation
+CODING_TOPIC_5=Trees and binary search trees - traversal, depth, validation, lowest common ancestor
+CODING_TOPIC_6=Graphs - BFS/DFS, connected components, basic shortest path
+CODING_TOPIC_7=Sorting and searching - binary search, merge intervals, kth largest element
+CODING_TOPIC_8=Dynamic programming - basic 1D/2D DP, memoization, simple optimization
+CODING_TOPIC_9=Recursion and backtracking - permutations, combinations, simple backtracking
+CODING_TOPIC_10=Greedy algorithms - interval scheduling, simple resource allocation

--- a/src/test/java/com/aicodinginterviewprep/QuestionTypeTest.java
+++ b/src/test/java/com/aicodinginterviewprep/QuestionTypeTest.java
@@ -7,13 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class QuestionTypeTest {
 
     @Test
-    void hasBehaviouralAndTheoryValues() {
-        assertEquals(2, QuestionType.values().length);
+    void hasBehaviouralTheoryAndCodingValues() {
+        assertEquals(3, QuestionType.values().length);
     }
 
     @Test
     void toStringReturnsHumanReadableLabel() {
         assertEquals("Behavioural", QuestionType.BEHAVIOURAL.toString());
         assertEquals("Theory", QuestionType.THEORY.toString());
+        assertEquals("Coding", QuestionType.CODING.toString());
     }
 }

--- a/src/test/java/com/aicodinginterviewprep/controllers/AuthControllerTest.java
+++ b/src/test/java/com/aicodinginterviewprep/controllers/AuthControllerTest.java
@@ -10,15 +10,19 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javafx.application.Platform;
 import javafx.scene.control.Button;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,9 +66,11 @@ class AuthControllerTest {
 
         controller.textfieldUsername = new TextField();
         controller.passwordfieldPassword = new PasswordField();
+        controller.textfieldPasswordVisible = new TextField();
         controller.buttonLogIn = new Button();
         controller.buttonSignUp = new Button();
         controller.buttonReturn = new Button();
+        controller.linkTogglePassword = new Hyperlink();
         controller.labelMessage = new Label();
 
         return controller;
@@ -250,6 +256,46 @@ class AuthControllerTest {
     }
 
     @Test
+    void passwordFieldsStayInSyncViaBidirectionalBinding() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            AuthController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.passwordfieldPassword.setText("secret123");
+            assertEquals("secret123", controller.textfieldPasswordVisible.getText());
+
+            controller.textfieldPasswordVisible.setText("changed");
+            assertEquals("changed", controller.passwordfieldPassword.getText());
+        });
+    }
+
+    @Test
+    void onTogglePasswordVisibilitySwapsFieldVisibilityAndButtonText() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            AuthController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            assertTrue(controller.passwordfieldPassword.isVisible());
+            assertFalse(controller.textfieldPasswordVisible.isVisible());
+            assertEquals("Show", controller.linkTogglePassword.getText());
+
+            controller.onTogglePasswordVisibility();
+
+            assertFalse(controller.passwordfieldPassword.isVisible());
+            assertTrue(controller.textfieldPasswordVisible.isVisible());
+            assertEquals("Hide", controller.linkTogglePassword.getText());
+
+            controller.onTogglePasswordVisibility();
+
+            assertTrue(controller.passwordfieldPassword.isVisible());
+            assertFalse(controller.textfieldPasswordVisible.isVisible());
+            assertEquals("Show", controller.linkTogglePassword.getText());
+        });
+    }
+
+    @Test
     void onReturnSwitchesToHomeScene() throws Exception {
         runOnFxThreadAndWait(() -> {
             AuthController controller = createController();
@@ -259,6 +305,73 @@ class AuthControllerTest {
             controller.onReturn();
 
             assertEquals("home", sceneManager.lastScene);
+        });
+    }
+
+    @Test
+    void onReturnClearsUsernameAndPasswordAndResetsVisibility() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            AuthController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.textfieldUsername.setText("alice");
+            controller.passwordfieldPassword.setText("secret123");
+            controller.onTogglePasswordVisibility();
+
+            controller.onReturn();
+
+            assertEquals("", controller.textfieldUsername.getText());
+            assertEquals("", controller.passwordfieldPassword.getText());
+            assertEquals("", controller.textfieldPasswordVisible.getText());
+            assertTrue(controller.passwordfieldPassword.isVisible());
+            assertFalse(controller.textfieldPasswordVisible.isVisible());
+            assertEquals("Show", controller.linkTogglePassword.getText());
+        });
+    }
+
+    @Test
+    void tabFromUsernameSkipsAheadToPasswordField() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            AuthController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            KeyEvent tab = new KeyEvent(
+                KeyEvent.KEY_PRESSED, "", "", KeyCode.TAB, false, false, false, false);
+            controller.textfieldUsername.getOnKeyPressed().handle(tab);
+
+            assertTrue(tab.isConsumed(), "Tab out of username should be handled explicitly");
+        });
+    }
+
+    @Test
+    void tabFromPasswordFieldSkipsAheadToShowLink() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            AuthController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            KeyEvent tab = new KeyEvent(
+                KeyEvent.KEY_PRESSED, "", "", KeyCode.TAB, false, false, false, false);
+            controller.passwordfieldPassword.getOnKeyPressed().handle(tab);
+
+            assertTrue(tab.isConsumed(), "Tab out of the password field should be handled explicitly");
+        });
+    }
+
+    @Test
+    void shiftTabIsLeftToDefaultBackwardTraversal() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            AuthController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            KeyEvent shiftTab = new KeyEvent(
+                KeyEvent.KEY_PRESSED, "", "", KeyCode.TAB, true, false, false, false);
+            controller.passwordfieldPassword.getOnKeyPressed().handle(shiftTab);
+
+            assertFalse(shiftTab.isConsumed(), "Shift+Tab should fall back to default traversal");
         });
     }
 

--- a/src/test/java/com/aicodinginterviewprep/controllers/CodingControllerTest.java
+++ b/src/test/java/com/aicodinginterviewprep/controllers/CodingControllerTest.java
@@ -1,0 +1,403 @@
+package com.aicodinginterviewprep.controllers;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.aicodinginterviewprep.QuestionType;
+import com.aicodinginterviewprep.SceneManager;
+import com.aicodinginterviewprep.service.OpenAiQuestionService;
+
+import javafx.application.Platform;
+import javafx.scene.control.Button;
+import javafx.scene.control.TextArea;
+import javafx.stage.Stage;
+
+class CodingControllerTest {
+
+    @BeforeAll
+    static void initialiseJavaFx() {
+        try {
+            Platform.startup(() -> {});
+        } catch (IllegalStateException ignored) {
+            // JavaFX already started.
+        }
+    }
+
+    private void runOnFxThreadAndWait(Runnable action) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicReference<Throwable> error =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+
+        if (error.get() != null) {
+            if (error.get() instanceof AssertionError assertionError) {
+                throw assertionError;
+            }
+
+            throw new RuntimeException(error.get());
+        }
+    }
+
+    private void setQuestionService(CodingController controller, OpenAiQuestionService service) {
+        try {
+            Field field = CodingController.class.getDeclaredField("questionService");
+            field.setAccessible(true);
+            field.set(controller, service);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CodingController createController() {
+        CodingController controller = new CodingController();
+
+        controller.questionOutput = new TextArea();
+        controller.codeEditor = new TextArea();
+
+        controller.buttonReturn = new Button();
+        controller.buttonSubmitAnswer = new Button();
+        controller.buttonGenerateQuestion = new Button();
+        controller.buttonPractice = new Button();
+
+        return controller;
+    }
+
+    @Test
+    void onReturn_switchesToHomeScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.onReturn();
+
+            assertEquals("home", sceneManager.lastScene);
+        });
+    }
+
+    @Test
+    void onPractice_switchesToPracticeScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.onPractice();
+
+            assertEquals("practice", sceneManager.lastScene);
+        });
+    }
+
+    @Test
+    void runEvaluation_switchesToFeedbackScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.runEvaluation();
+
+            assertEquals("feedback", sceneManager.lastScene);
+        });
+    }
+
+    @Test
+    void runEvaluation_passesControlsAndCodingReturnSceneToFeedbackController() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeFeedbackController feedbackController = new FakeFeedbackController();
+            FakeSceneManager sceneManager = new FakeSceneManager(feedbackController);
+            controller.setSceneManager(sceneManager);
+
+            controller.runEvaluation();
+
+            assertEquals(controller.questionOutput, feedbackController.receivedQuestionOutput);
+            assertEquals(controller.codeEditor, feedbackController.receivedCodeEditor);
+            assertNull(feedbackController.receivedAnswerInput);
+            assertEquals("coding", feedbackController.receivedReturnScene);
+        });
+    }
+
+    @Test
+    void runEvaluation_callsFeedbackRunEvaluation() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeFeedbackController feedbackController = new FakeFeedbackController();
+            FakeSceneManager sceneManager = new FakeSceneManager(feedbackController);
+            controller.setSceneManager(sceneManager);
+
+            controller.runEvaluation();
+
+            assertTrue(feedbackController.evaluationCalled);
+        });
+    }
+
+    @Test
+    void runEvaluation_whenFeedbackControllerMissing_doesNotCrash() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.runEvaluation();
+
+            assertEquals("feedback", sceneManager.lastScene);
+        });
+    }
+
+    @Test
+    void onSubmitAnswer_startsEvaluationFlow() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            FakeFeedbackController feedbackController = new FakeFeedbackController();
+            FakeSceneManager sceneManager = new FakeSceneManager(feedbackController);
+            controller.setSceneManager(sceneManager);
+
+            controller.onSubmitAnswer();
+
+            assertEquals("feedback", sceneManager.lastScene);
+            assertTrue(feedbackController.evaluationCalled);
+        });
+    }
+
+    @Test
+    void onGenerateQuestion_resetsCodeEditorToStarterCode() throws Exception {
+        BlockingQuestionService service = new BlockingQuestionService();
+
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            controller.setSceneManager(new FakeSceneManager());
+            setQuestionService(controller, service);
+
+            controller.codeEditor.setText("public int[] mySolution() { return null; }");
+
+            controller.onGenerateQuestion();
+
+            assertEquals("// Write your code here", controller.codeEditor.getText());
+        });
+
+        service.release();
+    }
+
+    @Test
+    void onGenerateQuestion_showsLoadingState() throws Exception {
+        BlockingQuestionService service = new BlockingQuestionService();
+        CodingController[] holder = new CodingController[1];
+
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            holder[0] = controller;
+
+            controller.setSceneManager(new FakeSceneManager());
+            setQuestionService(controller, service);
+
+            controller.onGenerateQuestion();
+
+            assertEquals("Generating question...", controller.questionOutput.getText());
+            assertTrue(controller.buttonGenerateQuestion.isDisabled());
+        });
+
+        service.release();
+    }
+
+    @Test
+    void onGenerateQuestion_successDisplaysQuestion() throws Exception {
+        FakeQuestionService service = new FakeQuestionService("Title: Two Sum\nDifficulty: Easy");
+        CodingController[] holder = new CodingController[1];
+        CountDownLatch completed = new CountDownLatch(1);
+
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            holder[0] = controller;
+
+            controller.setSceneManager(new FakeSceneManager());
+            setQuestionService(controller, service);
+
+            controller.questionOutput.textProperty().addListener((observable, oldValue, newValue) -> {
+                if ("Title: Two Sum\nDifficulty: Easy".equals(newValue)) {
+                    completed.countDown();
+                }
+            });
+
+            controller.onGenerateQuestion();
+        });
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS));
+
+        runOnFxThreadAndWait(() -> {
+            assertEquals("Title: Two Sum\nDifficulty: Easy", holder[0].questionOutput.getText());
+            assertFalse(holder[0].buttonGenerateQuestion.isDisabled());
+        });
+    }
+
+    @Test
+    void onGenerateQuestion_alwaysRequestsCodingQuestionType() throws Exception {
+        RecordingQuestionService service = new RecordingQuestionService();
+        CountDownLatch completed = service.completed;
+
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            controller.setSceneManager(new FakeSceneManager());
+            setQuestionService(controller, service);
+
+            controller.onGenerateQuestion();
+        });
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS));
+        assertEquals(QuestionType.CODING, service.receivedType);
+    }
+
+    @Test
+    void onGenerateQuestion_failureDisplaysError() throws Exception {
+        FailingQuestionService service = new FailingQuestionService();
+        CodingController[] holder = new CodingController[1];
+        CountDownLatch failed = new CountDownLatch(1);
+
+        runOnFxThreadAndWait(() -> {
+            CodingController controller = createController();
+            holder[0] = controller;
+
+            controller.setSceneManager(new FakeSceneManager());
+            setQuestionService(controller, service);
+
+            controller.questionOutput.textProperty().addListener((observable, oldValue, newValue) -> {
+                if (newValue.startsWith("Failed to generate question:")) {
+                    failed.countDown();
+                }
+            });
+
+            controller.onGenerateQuestion();
+        });
+
+        assertTrue(failed.await(5, TimeUnit.SECONDS));
+
+        runOnFxThreadAndWait(() -> {
+            assertEquals("Failed to generate question: Test API failure", holder[0].questionOutput.getText());
+            assertFalse(holder[0].buttonGenerateQuestion.isDisabled());
+        });
+    }
+
+    private static class FakeSceneManager extends SceneManager {
+        String lastScene;
+        private final Object feedbackController;
+
+        FakeSceneManager() {
+            this(null);
+        }
+
+        FakeSceneManager(Object feedbackController) {
+            super(new Stage());
+            this.feedbackController = feedbackController;
+        }
+
+        @Override
+        public void switchToScene(String sceneName) {
+            lastScene = sceneName;
+        }
+
+        @Override
+        public Object getController(String sceneName) {
+            if ("feedback".equals(sceneName)) {
+                return feedbackController;
+            }
+            return null;
+        }
+    }
+
+    private static class FakeFeedbackController extends FeedbackController {
+        TextArea receivedQuestionOutput;
+        TextArea receivedCodeEditor;
+        javafx.scene.control.TextInputControl receivedAnswerInput;
+        String receivedReturnScene;
+
+        boolean evaluationCalled = false;
+
+        @Override
+        public void setAnswerControls(
+                TextArea questionOutput,
+                TextArea codeEditor,
+                javafx.scene.control.TextInputControl answerInput,
+                String returnScene) {
+
+            this.receivedQuestionOutput = questionOutput;
+            this.receivedCodeEditor = codeEditor;
+            this.receivedAnswerInput = answerInput;
+            this.receivedReturnScene = returnScene;
+        }
+
+        @Override
+        public void runEvaluation() {
+            evaluationCalled = true;
+        }
+    }
+
+    private static class BlockingQuestionService extends OpenAiQuestionService {
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public String generateQuestion(QuestionType type) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return "Generated question";
+        }
+
+        void release() {
+            latch.countDown();
+        }
+    }
+
+    private static class FakeQuestionService extends OpenAiQuestionService {
+        private final String result;
+
+        FakeQuestionService(String result) {
+            this.result = result;
+        }
+
+        @Override
+        public String generateQuestion(QuestionType type) {
+            return result;
+        }
+    }
+
+    private static class RecordingQuestionService extends OpenAiQuestionService {
+        QuestionType receivedType;
+        CountDownLatch completed = new CountDownLatch(1);
+
+        @Override
+        public String generateQuestion(QuestionType type) {
+            receivedType = type;
+            completed.countDown();
+            return "Test question";
+        }
+    }
+
+    private static class FailingQuestionService extends OpenAiQuestionService {
+        @Override
+        public String generateQuestion(QuestionType type) {
+            throw new RuntimeException("Test API failure");
+        }
+    }
+}

--- a/src/test/java/com/aicodinginterviewprep/controllers/FeedbackControllerTest.java
+++ b/src/test/java/com/aicodinginterviewprep/controllers/FeedbackControllerTest.java
@@ -99,6 +99,37 @@ class FeedbackControllerTest {
     }
 
     @Test
+    void setAnswerControls_withReturnScene_storesReferencesAndReturnScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            FeedbackController controller = createController();
+            TextArea questionOutput = new TextArea();
+            TextArea codeEditor = new TextArea();
+            TextField answerInput = new TextField();
+
+            controller.setAnswerControls(questionOutput, codeEditor, answerInput, "coding");
+
+            assertEquals(questionOutput, getPrivateField(controller, "questionOutput"));
+            assertEquals(codeEditor, getPrivateField(controller, "codeEditor"));
+            assertEquals(answerInput, getPrivateField(controller, "answerInput"));
+            assertEquals("coding", getPrivateField(controller, "returnScene"));
+        });
+    }
+
+    @Test
+    void onTryAgain_afterCodingEvaluation_switchesBackToCodingScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            FeedbackController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+
+            controller.setSceneManager(sceneManager);
+            controller.setAnswerControls(new TextArea(), new TextArea(), new TextField(), "coding");
+            controller.onTryAgain();
+
+            assertEquals("coding", sceneManager.lastScene);
+        });
+    }
+
+    @Test
     void runEvaluation_whenQuestionIsEmpty_showsErrorMessage() throws Exception {
         runOnFxThreadAndWait(() -> {
             FeedbackController controller = createController();
@@ -222,7 +253,6 @@ class FeedbackControllerTest {
 
             controller.runEvaluation();
 
-            assertTrue(controller.buttonSubmitAnswer.isDisabled());
             assertTrue(controller.buttonTryAgain.isDisabled());
         });
 
@@ -302,7 +332,6 @@ class FeedbackControllerTest {
         assertTrue(completed.await(5, TimeUnit.SECONDS));
 
         runOnFxThreadAndWait(() -> {
-            assertFalse(holder[0].buttonSubmitAnswer.isDisabled());
             assertFalse(holder[0].buttonTryAgain.isDisabled());
         });
     }
@@ -380,7 +409,6 @@ class FeedbackControllerTest {
         assertTrue(completed.await(5, TimeUnit.SECONDS));
 
         runOnFxThreadAndWait(() -> {
-            assertFalse(holder[0].buttonSubmitAnswer.isDisabled());
             assertFalse(holder[0].buttonTryAgain.isDisabled());
         });
     }
@@ -528,7 +556,6 @@ class FeedbackControllerTest {
         FeedbackController controller = new FeedbackController();
         controller.textareaEvaluation = new TextArea();
         controller.buttonTryAgain = new Button();
-        controller.buttonSubmitAnswer = new Button();
         return controller;
     }
 

--- a/src/test/java/com/aicodinginterviewprep/controllers/HomeControllerTest.java
+++ b/src/test/java/com/aicodinginterviewprep/controllers/HomeControllerTest.java
@@ -1,0 +1,75 @@
+package com.aicodinginterviewprep.controllers;
+
+import com.aicodinginterviewprep.SceneManager;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HomeControllerTest {
+
+    @BeforeAll
+    static void initialiseJavaFx() {
+        try {
+            Platform.startup(() -> {});
+        } catch (IllegalStateException ignored) {
+            // JavaFX already started.
+        }
+    }
+
+    private void runOnFxThreadAndWait(Runnable action) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        Platform.runLater(() -> {
+            try {
+                action.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        latch.await();
+
+        if (error.get() != null) {
+            if (error.get() instanceof AssertionError assertionError) {
+                throw assertionError;
+            }
+            throw new RuntimeException(error.get());
+        }
+    }
+
+    @Test
+    void onGetStartedSwitchesToAuthenticationScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            HomeController controller = new HomeController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+
+            controller.onGetStarted();
+
+            assertEquals("authentication", sceneManager.lastScene);
+        });
+    }
+
+    private static class FakeSceneManager extends SceneManager {
+        String lastScene;
+
+        FakeSceneManager() {
+            super(new Stage());
+        }
+
+        @Override
+        public void switchToScene(String sceneName) {
+            lastScene = sceneName;
+        }
+    }
+}

--- a/src/test/java/com/aicodinginterviewprep/controllers/PracticeControllerTest.java
+++ b/src/test/java/com/aicodinginterviewprep/controllers/PracticeControllerTest.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,6 @@ import javafx.application.Platform;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextArea;
-import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 
 class PracticeControllerTest {
@@ -83,9 +83,11 @@ class PracticeControllerTest {
             controller.setSceneManager(sceneManager);
 
             assertEquals(
-                    QuestionType.values().length,
+                    2,
                     controller.comboQuestionType.getItems().size()
             );
+            assertTrue(controller.comboQuestionType.getItems().contains(QuestionType.BEHAVIOURAL));
+            assertTrue(controller.comboQuestionType.getItems().contains(QuestionType.THEORY));
         });
     }
 
@@ -114,6 +116,19 @@ class PracticeControllerTest {
             controller.onReturn();
 
             assertEquals("home", sceneManager.lastScene);
+        });
+    }
+
+    @Test
+    void onCodingPractice_switchesToCodingScene() throws Exception {
+        runOnFxThreadAndWait(() -> {
+            PracticeController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+
+            controller.setSceneManager(sceneManager);
+            controller.onCodingPractice();
+
+            assertEquals("coding", sceneManager.lastScene);
         });
     }
 
@@ -150,15 +165,14 @@ class PracticeControllerTest {
                     feedbackController.receivedQuestionOutput
             );
 
-            assertEquals(
-                    controller.codeEditor,
-                    feedbackController.receivedCodeEditor
-            );
+            assertNull(feedbackController.receivedCodeEditor);
 
             assertEquals(
                     controller.answerInput,
                     feedbackController.receivedAnswerInput
             );
+
+            assertEquals("practice", feedbackController.receivedReturnScene);
         });
     }
 
@@ -216,13 +230,12 @@ class PracticeControllerTest {
 
         controller.comboQuestionType = new ComboBox<>();
         controller.questionOutput = new TextArea();
-        controller.codeEditor = new TextArea();
-        controller.answerInput = new TextField();
+        controller.answerInput = new TextArea();
 
         controller.buttonReturn = new Button();
         controller.buttonSubmitAnswer = new Button();
-        controller.buttonRunEvaluation = new Button();
         controller.buttonGenerateQuestion = new Button();
+        controller.buttonCodingPractice = new Button();
 
         return controller;
     }
@@ -274,6 +287,26 @@ class PracticeControllerTest {
             assertEquals("feedback", sceneManager.lastScene);
             assertTrue(feedbackController.evaluationCalled);
         });
+    }
+
+    @Test
+    void onGenerateQuestion_clearsPreviousAnswer() throws Exception {
+        BlockingQuestionService service = new BlockingQuestionService();
+
+        runOnFxThreadAndWait(() -> {
+            PracticeController controller = createController();
+            FakeSceneManager sceneManager = new FakeSceneManager();
+            controller.setSceneManager(sceneManager);
+            setQuestionService(controller, service);
+
+            controller.answerInput.setText("My old answer from the previous question");
+
+            controller.onGenerateQuestion();
+
+            assertEquals("", controller.answerInput.getText());
+        });
+
+        service.release();
     }
 
     @Test
@@ -465,7 +498,8 @@ class PracticeControllerTest {
 
         TextArea receivedQuestionOutput;
         TextArea receivedCodeEditor;
-        TextField receivedAnswerInput;
+        javafx.scene.control.TextInputControl receivedAnswerInput;
+        String receivedReturnScene;
 
         boolean evaluationCalled = false;
 
@@ -473,14 +507,13 @@ class PracticeControllerTest {
         public void setAnswerControls(
                 TextArea questionOutput,
                 TextArea codeEditor,
-                javafx.scene.control.TextInputControl answerInput) {
+                javafx.scene.control.TextInputControl answerInput,
+                String returnScene) {
 
             this.receivedQuestionOutput = questionOutput;
             this.receivedCodeEditor = codeEditor;
-
-            if (answerInput instanceof TextField textField) {
-                this.receivedAnswerInput = textField;
-            }
+            this.receivedAnswerInput = answerInput;
+            this.receivedReturnScene = returnScene;
         }
 
         @Override

--- a/src/test/java/com/aicodinginterviewprep/service/OpenAiQuestionServiceTest.java
+++ b/src/test/java/com/aicodinginterviewprep/service/OpenAiQuestionServiceTest.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -94,5 +95,103 @@ class OpenAiQuestionServiceTest {
         }
 
         assertTrue(seen.size() > 1, "expected topic rotation to produce more than one distinct prompt");
+    }
+
+    @Test
+    void buildUserPromptFillsInACodingTopicArea() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        String prompt = service.buildUserPrompt(QuestionType.CODING);
+
+        assertTrue(prompt.contains("Focus specifically on this topic area:"));
+    }
+
+    @Test
+    void buildUserPromptRotatesAcrossMultipleCodingTopics() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            seen.add(service.buildUserPrompt(QuestionType.CODING));
+        }
+
+        assertTrue(seen.size() > 1, "expected topic rotation to produce more than one distinct prompt");
+    }
+
+    @Test
+    void buildUserPromptAlwaysFillsInACodingDifficulty() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        for (int i = 0; i < 20; i++) {
+            String prompt = service.buildUserPrompt(QuestionType.CODING);
+            assertFalse(prompt.contains("{difficulty}"), "difficulty placeholder should always be filled in: " + prompt);
+            assertTrue(
+                prompt.contains("Easy difficulty") || prompt.contains("Medium difficulty") || prompt.contains("Hard difficulty"),
+                "expected an explicit difficulty in the prompt: " + prompt
+            );
+        }
+    }
+
+    @Test
+    void buildUserPromptRotatesAcrossAllThreeCodingDifficulties() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        Set<String> seenDifficulties = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            String prompt = service.buildUserPrompt(QuestionType.CODING);
+            if (prompt.contains("Easy difficulty")) {
+                seenDifficulties.add("Easy");
+            } else if (prompt.contains("Medium difficulty")) {
+                seenDifficulties.add("Medium");
+            } else if (prompt.contains("Hard difficulty")) {
+                seenDifficulties.add("Hard");
+            }
+        }
+
+        assertEquals(Set.of("Easy", "Medium", "Hard"), seenDifficulties);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void generateQuestionForCodingReturnsFullLeetCodeStyleContent() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(
+            "{\"choices\":[{\"message\":{\"content\":\"Title: Two Sum\\nDifficulty: Easy\"}}]}");
+        when(httpClient.<String>send(any(HttpRequest.class), any())).thenReturn(response);
+
+        OpenAiQuestionService service = new OpenAiQuestionService(httpClient, "fake-key", "gpt-5-nano");
+
+        assertEquals("Title: Two Sum\nDifficulty: Easy", service.generateQuestion(QuestionType.CODING));
+    }
+
+    @Test
+    void systemPromptForCodingUsesDedicatedCodingSystemPrompt() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        String codingSystemPrompt = service.systemPromptFor(QuestionType.CODING);
+        String theorySystemPrompt = service.systemPromptFor(QuestionType.THEORY);
+
+        assertTrue(codingSystemPrompt.contains("LeetCode-style"));
+        assertFalse(codingSystemPrompt.equals(theorySystemPrompt), "coding should use its own system prompt");
+    }
+
+    @Test
+    void systemPromptForNonCodingTypesFallsBackToSharedSystemPrompt() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        assertEquals(
+            service.systemPromptFor(QuestionType.BEHAVIOURAL),
+            service.systemPromptFor(QuestionType.THEORY)
+        );
+    }
+
+    @Test
+    void maxCompletionTokensForCodingIsLargerThanDefault() {
+        OpenAiQuestionService service = new OpenAiQuestionService(mock(HttpClient.class), "key", "model");
+
+        assertTrue(service.maxCompletionTokensFor(QuestionType.CODING)
+            > service.maxCompletionTokensFor(QuestionType.THEORY));
     }
 }


### PR DESCRIPTION
## Summary
- Adds a Coding question type, generated the same prompt-engineered way as Behavioural/Theory, with a dedicated LeetCode-style tab (question + code editor, no separate explanation box)
- Server picks the difficulty (Easy/Medium/Hard) itself now instead of leaving it to the model, since it defaulted to Medium almost every time
- Fixes Try Again on the feedback screen always returning to Practice even when you came from Coding
- Generating a new question now clears whatever was left over from the previous one
- Redesigned the Home screen (one Get Started button instead of two that did the same thing) and the Log In / Sign Up screen (labeled underline-style fields, show/hide password, proper tab order, consistent alignment - also found and fixed a stray global CSS rule capping every text field at 180px)
- Removed a dead Submit Answer button on the feedback screen that had no click handler at all
- Widened a few buttons whose fixed width was sized for a smaller font and was clipping their text

## Test plan
- Full suite passes: 134 tests, 0 failures
- Manually walked through sign up, log in, generating both Coding and Behavioural/Theory questions, and running AI evaluation from both tabs