### PR TITLE
Fix stale README, wiki wording, and fork-PR CI handling

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 17
 
       - name: Set up Node 20
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,15 +11,14 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    # Fork PRs don't get repository secrets (SONAR_TOKEN etc.), so this job
+    # can't authenticate for them. Skip it entirely instead of failing loudly -
+    # a fork PR is still a valid way to contribute, it just won't get a
+    # SonarCloud check on that PR. Team members with push access should still
+    # push branches here directly to get the full CI signal (see CONTRIBUTING.md).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
-      - name: Reject fork pull requests
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "::error::This PR comes from a fork (${{ github.event.pull_request.head.repo.full_name }}). GitHub does not pass repository secrets to fork PRs, so SonarCloud cannot authenticate here."
-          echo "::error::All team members have push access to this repo — push your branch here directly instead of from a personal fork. See CONTRIBUTING.md."
-          exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,28 @@
 **Team Name:** Team 1
 **Team Members:** Scott Wallace, Gabriel Liu, Dylan Liddle, Neia Tererei, Kenny Geng, Dandan Wu, Shenol Peiris
 
-This repository contains the setup scaffolding for the SOFTENG 310 A1 project.
+This project is associated with the University of Auckland course SOFTENG 310
+(Software Evolution and Maintenance).
 
-## What is included
+AI Coding Interview Preparation is a JavaFX desktop app that helps software
+engineering students practice for technical interviews: it generates
+behavioural, theory, and LeetCode-style coding questions with OpenAI, grades
+written answers with AI feedback, and lets you answer by voice instead of
+typing.
 
-- Maven build configuration in `pom.xml`
-- JavaFX application scaffold in `src/main/java/com/aicodinginterviewprep/App.java`
-- Basic JUnit test in `src/test/java/com/aicodinginterviewprep/AppTest.java`
-- `.gitignore` to exclude build artifacts
+## Features
+
+- **Authentication** - sign up and log in, with account details persisted
+  between sessions
+- **Behavioural / Theory practice** - AI-generated interview questions with a
+  free-text answer box, evaluated against a grading rubric
+- **Coding practice** - LeetCode-style coding questions with a syntax-highlighted
+  code editor
+- **AI question generation and evaluation** - OpenAI generates the questions
+  and grades submitted answers, with a rating out of 10 and written feedback
+- **Voice input** - a "Record Answer" button transcribes speech into the
+  answer box, fully offline (see below), so it works without any OpenAI
+  access
 
 ## Technology Stack
 
@@ -76,7 +90,21 @@ that folder is missing, download and unzip it from:
 
 https://alphacephei.com/vosk/models/vosk-model-en-us-0.22-lgraph.zip
 
-## Notes
+## Known limitations / troubleshooting
 
-- This is setup-only scaffolding for the project; feature implementation can be added on top of this structure.
+- **Question generation and grading need internet access and an OpenAI
+  API key** - see "OpenAI API key setup" above. Each generated question and
+  each evaluation is a paid API call; the app doesn't work fully offline
+  except for voice input.
+- **Voice input accuracy is limited** by the offline speech model - it can
+  come back empty on unclear audio, and background noise is filtered out
+  rather than transcribed as junk text (see "Voice input" below).
+- **The Vosk model is not tracked in git** on purpose (it's ~200MB of binary
+  data) - if `models/vosk-model-en-us-0.22-lgraph/` is missing locally, voice
+  input will show a clear error telling you to download it; every other
+  feature works without it.
+- **Account data is stored as plaintext JSON** in
+  `src/main/resources/authorisation/accounts.json` - this is fine for local
+  development and demos, but isn't representative of how a real production
+  auth system would store credentials.
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -95,7 +95,7 @@ AI Coding Interview Prep is an AI-supported interview preparation tool that help
 - CONTRIBUTING.md: contribution process
 - TASKS.md: A1 tasks and A2 vision
 - Issue templates: bug report and feature request
-- Wiki: this page can be copied into the GitHub wiki
+- Wiki: this page is published on the [GitHub wiki](../../wiki) and mirrored here as `WIKI.md`
 
 ## Workflow Notes
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -24,10 +24,15 @@ AI Coding Interview Prep is an AI-supported interview preparation tool that help
 
 ### Gabriel Liu (@Gabeliu)
 * **Code Contributions:**
+  * Code editor syntax highlighting, voice input, auth fixes, and grading improvements - RichTextFX syntax highlighting, offline speech-to-text voice input on the Practice tab (Vosk, no OpenAI dependency), retry logic for flaky question generation, a stricter AI grading rubric, logged-in user indicator and log out, minimum window size (PR #57, closes #53 and #58)
+  * Wire up sign up and log in to the Authenticator (PR #50)
+  * Add LeetCode practice tab and redesign home/login screens (PR #52)
   * Remove stray editor lock file (PR #31, Issue #30)
   * Add AI-generated interview questions via OpenAI (PR #13, Issue #12)
   * Add initial JavaFX scaffold, Maven wrapper, documentation, and CI workflows (PR #3)
 * **Other Contributions:**
+  * Fix stale README, wiki wording, and fork-PR CI handling; close stale Issue #33, label Issue #26 (PR #59)
+  * Review on PR #56
   * Stop contributors from forking; guard SonarCloud against fork PRs (PR #17, Issue #18)
   * Document early direct-to-main commits as a workflow mistake (PR #7, Issue #6)
   * Revise README with project details and description (PR #1)


### PR DESCRIPTION
## Summary

Follow-up cleanup after #57 - fixes a few repo-hygiene issues that were still outstanding:

- README still described the project as "setup scaffolding" with the original file list and closed with "feature implementation can be added on top of this structure" - none of that reflected the app anymore. Rewrote it with an actual feature list (auth, practice questions, coding editor, AI grading, voice input) and a known limitations/troubleshooting section.
- Fixed the wiki doc index, which still said the wiki page "can be copied into the GitHub wiki" even though it's actually published there now.
- SonarCloud was hard-rejecting fork PRs with an error. Switched that to a job-level skip instead, so a fork PR just doesn't get a SonarCloud check rather than showing a red X - it's not a required status check, so this doesn't change what's needed to merge.
- Bumped `actions/setup-node` from v1 (deprecated) to v4 in the Snyk workflow.
- Closed #33 (auth was marked as "not implemented" but has been fully working since #50), labeled #26 which had no labels.

## Test plan

- [x] Full test suite passes (`./mvnw test`)
- [x] Validated both edited workflow YAML files parse correctly