### PR TITLE
added: meeting minuts to the WIKI

### DIFF
--- a/WIKI.md
+++ b/WIKI.md
@@ -123,13 +123,55 @@ action items for the next meeting.
 
 ### Template
 
-```
-### YYYY-MM-DD (In-person / Online)
-**Attendees:** 
-**Topics discussed:** 
-**Decisions made:** 
-**Issues/PRs referenced:** 
-**Action items:** 
-```
+
+### DD-MM-YYYY (In-person / Online)
+**Attendees:**<br>
+**Topics discussed:** <br>
+**Decisions made:** <br>
+**Issues/PRs referenced:** <br>
+**Action items:** <br>
+
+### 20-08-2026 (Online)
+**Attendees:** Dylan, Scott, Shenol, Neia, Gabriel, Kenny, Dandan<br>
+**Topics discussed:** Integrating Coding tab. adding voice input and fixing user authentication<br>
+**Decisions made:** Voice input will run offline and will not need API key. User authentication will be done locally for now. coding tab current is plain, so we decided to style it up.<br>
+**Issues/PRs referenced:** PR #28, PR #52<br>
+**Action items:** Try and finalise the app and do the github release and submit repo link to the submuission.
+
+### 17-08-2026 (In-person)
+**Attendees:** Dylan, Scott, Shenol, Neia, Gabriel, Kenny<br>
+**Topics discussed:** API key working. update on UI. making A2 issues. separating Fxml files (scenes) to different files<br>
+**Decisions made:** Decided to make custom A2 label for A2 issues related to part 2 of the project. checked on the current UI and gave feedback on how to improve it. made a scene for each tab in the app instead of everything in one java fle.<br>
+**Issues/PRs referenced:** PR #9, PR #13, PR #16, Issue #12, Issue #15, PR #22, Issue #21, PR #25<br>
+**Action items:** try and finalise the AI answers evaluation and question generation. try and improve the UI and its usability and finalise its controllers for javafx.
+
+### 13-08-2026 ()
+**Attendees:**<br>
+**Topics discussed:**<br>
+**Decisions made:**<br>
+**Issues/PRs referenced:** <br>
+**Action items:** No online meeting, everyone decided to use the time to work on their tasks as nothing much has happend.
+
+### 10-08-2026 (In-person)
+**Attendees:** Neia, Gabriel, Scott, Dandan, Kenny<br>
+**Topics discussed:** Referenced PR #3 (set up PR). update on teams progress with the projects. talked to the lectuer about API key<br>
+**Decisions made:** API key will take time so, AI question generation and AI answer evaluation can wait. Front-end can start without the AI components. We can use dummy data for now. <br>
+**Issues/PRs referenced:** PR #3<br>
+**Action items:** Work on UI, UI navigation. update documentation
+
+### 06-08-2026 (Online)
+**Attendees:** Dylan, Neia, Shenol, Gabriel, Scott, Dandan, Kenny<br>
+**Topics discussed:** Whos was gonna do what in the project.<br>
+**Decisions made:** made a google doc with each role written down to decide what roles to divide up between us.<br>
+Kenny is PM and API setup, Scott and Neia working on front-end and user authentication, Dandan working on Data Management, Shenol chose to work on AI answer evaluation, Gabriel chose to do AI question generation, Dylan working on Code tab (Code editor, Coding questions). <br>
+**Issues/PRs referenced:** none<br>
+**Action items:** Git repo setup before next meeting and some progress made with assgined tasks.
+
+### 03-08-2026 (In-person)
+**Attendees:** Dylan, Neia, Shenol, Gabriel, Scott, Dandan, Kenny<br>
+**Topics discussed:** Task breakdown, Overview of project. Talked about who wants to do what in the project.<br>
+**Decisions made:** Gave people untill the next meeting to decided and finalise on what tasks they were going to do/contribute to.<br>
+**Issues/PRs referenced:** none<br>
+**Action items:** individual teamates decides what to do before next meeting.
 
 <!-- Add one entry per meeting above this line, most recent first. -->


### PR DESCRIPTION
## Description
This PR adds the team meeting notes from August 3, 2026, through August 20, 2026

### Key Highlights
- **03-08-2026 (In-person):** Initial project overview and task breakdown.
- **06-08-2026 (Online):** Finalized team role and task assignments.
- **10-08-2026 (In-person):** API key timeline update; decided to use dummy data for front-end development in the interim.
- **13-08-2026:** Async work session record.
- **17-08-2026 (In-person):** Created custom `A2` issue labels, UI review, and refactored JavaFX scenes into separate FXML files.
- **20-08-2026 (Online):** Finalized offline voice input strategy, local authentication model, Coding tab styling, and prepare for final release submission.