### PR TITLE
Add AI-tool disclosure, issue-approval docs, and Snyk org targeting

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+env:
+  # Team1-SOFTENG310 shared Snyk org - explicit so this doesn't silently
+  # depend on whichever personal account SNYK_TOKEN happens to belong to
+  SNYK_ORG_ID: 6b41770b-b8ed-46b7-a3bd-889fddda4515
+
 jobs:
   snyk:
     runs-on: ubuntu-latest
@@ -34,7 +39,7 @@ jobs:
         run: snyk auth $SNYK_TOKEN
 
       - name: Run Snyk test
-        run: snyk test --all-projects
+        run: snyk test --all-projects --org=$SNYK_ORG_ID
 
       - name: Run Snyk monitor
-        run: snyk monitor --all-projects
+        run: snyk monitor --all-projects --org=$SNYK_ORG_ID

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ SE310_Assignment1_2026.pdf
 
 # Vosk speech model - large binary, download separately (see README)
 models/
+
+# Local Claude Code session/config directory - machine-local, not project config
+.claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing to AI Coding Interview Prep.
 
 ## How to contribute
 
-1. Clone this repository directly — do not fork it. All team members have push access, and PRs opened from a personal fork do not receive the `SONAR_TOKEN` secret, so SonarCloud fails on them (see #14).
+1. Clone this repository directly rather than forking it. All team members already have push access, so forking isn't necessary to contribute — and GitHub doesn't pass repository secrets (like `SONAR_TOKEN`) to workflows triggered by pull requests from a fork, so SonarCloud can't run on those PRs (we hit this with PR #14). Forking is still possible if you prefer it, but a fork PR won't get a SonarCloud check — push a branch here directly if you want that signal.
 2. Create a branch for your change: `git checkout -b feature-name`.
 3. Make small, focused commits.
 4. Push your branch to GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ Thank you for contributing to AI Coding Interview Prep.
 
 - Use issue templates for bug reports and feature requests.
 - Link pull requests to the related issue when possible.
+- Before starting work, check that no one else is already assigned - assign
+  yourself (or ask a maintainer to assign you) so effort isn't duplicated.
+
+## Issue approval
+
+New issues (bug reports or feature requests) need team approval before anyone
+starts work on them:
+
+- Bring new issues up at the next weekly meeting (Monday in-person or
+  Thursday online), or
+- If it can't wait for a meeting, approval can come from a comment or
+  reaction from at least one other team member.
+
+Either way, record the approval as a comment on the issue itself (e.g. "approved,
+go ahead") before work begins, so there's a record of when and how it was approved.
 
 ## Code quality
 

--- a/README.md
+++ b/README.md
@@ -120,3 +120,11 @@ own use of generative AI tools below.
   existing code. All AI-assisted output was reviewed and tested before being
   committed.
 
+- **Dandan Wu**: Used ChatGPT for: 
+  1: Analysing error messages and locating affected classes.
+  2: Find xvfb solution to avoid SonarCloud running forever.
+  3: Finding a method to fake Ai service without changing initial controller
+  code. 
+  4: Generated follow up test cases from initially written test cases.
+  5: Explanation of why unable to achieve particular branch for coverage. 
+  All AI-assisted output was reviewed and tested before committed.

--- a/README.md
+++ b/README.md
@@ -108,3 +108,15 @@ https://alphacephei.com/vosk/models/vosk-model-en-us-0.22-lgraph.zip
   development and demos, but isn't representative of how a real production
   auth system would store credentials.
 
+## Generative AI Tool Use
+
+In line with the SOFTENG 310 assignment brief, team members disclose their
+own use of generative AI tools below.
+
+- **Gabriel Liu**: Used Claude for planning and guidance on new features,
+  with some code written by the AI and reviewed before committing; used it
+  to help debug issues that came up while getting the app running; some test
+  cases were AI-generated; and used it for refactoring suggestions on
+  existing code. All AI-assisted output was reviewed and tested before being
+  committed.
+


### PR DESCRIPTION
## Summary

These commits were originally queued on the branch that became #59, but #59 got merged before they were pushed - opening a fresh PR off current main so nothing gets lost.

- Explain the no-fork decision in CONTRIBUTING.md instead of just stating it (forking is still possible, just won't get a SonarCloud check)
- Explicitly gitignore `.claude/` - it was only excluded via a personal global gitignore, not guaranteed for every contributor
- Document the issue-approval process (weekly meeting or a comment from one other member, recorded on the issue)
- Add the generative AI tool use disclosure section to README, with my own usage documented - open for other team members to add theirs
- Point the Snyk workflow at the shared Team1-SOFTENG310 org explicitly instead of depending on whichever personal account's token is in SNYK_TOKEN

## Test plan

- [x] Compiles cleanly
- [x] Verified each change is present after cherry-picking onto a fresh branch off main